### PR TITLE
Add sample code for adding custom claims

### DIFF
--- a/IdentityServer/CustomTokenRequestValidator.cs
+++ b/IdentityServer/CustomTokenRequestValidator.cs
@@ -1,0 +1,25 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using IdentityServer4.Validation;
+
+namespace IdentityServer
+{
+    // If you need to add custom CLIENT claims in the client credentials
+    // flow, you need to use a ICustomTokenRequestValidator.
+    // 
+    // This is only applicable to the client credentials flow.
+    // 
+    // Please note that client claims are differently configured from USER
+    // claims.  If you want to add custom USER claims, you need to use
+    // IProfileService.
+    public class CustomTokenRequestValidator : ICustomTokenRequestValidator
+    {
+        public Task ValidateAsync(CustomTokenRequestValidationContext context)
+        {
+            context.Result.ValidatedRequest.ClientClaims.Add(new Claim("my:client", "is:special"));
+
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/IdentityServer/ProfileService.cs
+++ b/IdentityServer/ProfileService.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using IdentityServer4.Models;
+using IdentityServer4.Services;
+
+namespace IdentityServer
+{
+    // If you need to add custom USER claims, you need to use a
+    // IProfileService.
+    //
+    // This is NOT applicable to the client credentials flow.
+    public class ProfileService : IProfileService
+    {
+        public Task GetProfileDataAsync(ProfileDataRequestContext context)
+        {
+            context.IssuedClaims.Add(new Claim("special", "martin"));
+
+            return Task.CompletedTask;
+        }
+
+        public Task IsActiveAsync(IsActiveContext context)
+        {
+            context.IsActive = true;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/IdentityServer/Startup.cs
+++ b/IdentityServer/Startup.cs
@@ -35,6 +35,10 @@ namespace IdentityServer
                 options.Events.RaiseSuccessEvents = true;
             })
                 .AddTestUsers(TestUsers.Users);
+                //
+                // If you want to add custom claims to the access token:
+                // .AddProfileService<ProfileService>() // User Claims
+                // .AddCustomTokenRequestValidator<CustomTokenRequestValidator>(); // Client claims
 
             // in-memory, code config
             builder.AddInMemoryIdentityResources(Config.Ids);


### PR DESCRIPTION
This commit will add sample code that describes how you can add custom
USER and CLIENT claims to the access token.  It is commented out, and
is added for reference only.  This is a common scenario that can be a
little tricky to figure out (especially for the client scenario.)